### PR TITLE
Include And Introduction function

### DIFF
--- a/src/discretemaths/Proof.java
+++ b/src/discretemaths/Proof.java
@@ -7,6 +7,7 @@ import discretemaths.forms.False;
 import discretemaths.forms.Form;
 import discretemaths.rules.AndE1;
 import discretemaths.rules.AndE2;
+import discretemaths.rules.AndI;
 import discretemaths.rules.BiimpliesE1;
 import discretemaths.rules.BiimpliesE2;
 import discretemaths.rules.BiimpliesI;
@@ -309,6 +310,11 @@ public class Proof {
 	public Proof andE2(int conjunction)
 	{
 		return rule(new AndE2(conjunction));
+	}
+	
+	public Proof andI(int a, int b)
+	{
+		return rule(new AndE2(a , b));
 	}
 
 	public Proof impliesE(int implication, int truth)


### PR DESCRIPTION
Currently the program doesn't allow you to use the ^Intro rule because the method andI(int a, int b) isn't located in the Proof class. Thought I'd let you know and submit a solution. :)