### PR TITLE
For All Introduction Bug Fix

### DIFF
--- a/src/discretemaths/rules/ForallI.java
+++ b/src/discretemaths/rules/ForallI.java
@@ -26,13 +26,13 @@ public class ForallI extends Rule{
 		if (p.getSubstNew()!=null || p.getSubstOld()!=null)
 			throw new InvalidRuleException("ForallE - Unexpected variable substitution found at line "+ line);
 		else {
-			int currentDepth = proof.getCurrentDepth()-1;
+			int currentDepth = proof.getCurrentDepth();
 			for (int i = proof.getCurrentLine(); i>0; i--){
 				if (proof.getDepth(i) <= currentDepth)
 					if (proof.getReason(i).getClass() == SubHyp.class
 					 || proof.getReason(i).getClass() == Hyp.class){
 						if (proof.getLine(i).occursFree(var))
-							throw new Exception(var + " occurs free in line " + i+1);
+							throw new Exception(var + " occurs free in line " + (i));
 						else
 							occursFreeCheck += var + "\\" + i + ",";
 					}


### PR DESCRIPTION
The For All introduction rule does not check all the open hypotheses and sub-hypotheses when checking if x is bound as it was not checking if x is bound in the current hypothesis/sub-hypothesis in which the for all introduction itself is found. In turn, this lead to proofs which should be incorrect to be accepted and worked out by the program.

The fix for this was to make sure that the currentDepth is correctly representative of the actual depth of the for all introduction within the proof (basically removing the -1). The error string generated by the class was also modified to be correctly representative of the depth within the proof.

-Bradley